### PR TITLE
Scoring lead card wins fix

### DIFF
--- a/euchre/__main__.py
+++ b/euchre/__main__.py
@@ -142,8 +142,9 @@ def get_highest_rank_card(cards: list[tuple[Player, Card]], trump: Trump) -> tup
     for this_card in cards:
         card = this_card[1]
 
-        # Check if the card is trump suit
-        card.is_trump(trump)
+        # Check if the card is trump suit, update if true
+        if card.is_trump(trump):
+            card.update_to_trump(trump)
 
         if card == first_card:
             continue

--- a/euchre/__main__.py
+++ b/euchre/__main__.py
@@ -141,20 +141,19 @@ def get_highest_rank_card(cards: list[tuple[Player, Card]], trump: Trump) -> tup
     
     for this_card in cards:
         card = this_card[1]
-        if card == highest_card:
-            # Check for Trump on first card to assign correct value
-            card.is_trump(trump)
+
+        # Check if the card is trump suit
+        card.is_trump(trump)
+
+        if card == first_card:
             continue
 
-        if card.is_trump(trump):
+        # Only compare cards that have the matching value or have a trump suit
+        if card.get_suit() == first_card.get_suit() or card.get_suit() == trump.get_suit():
+
             if card.get_value() > highest_card.get_value():
                 highest_card = card
                 winning_card = this_card
-
-        # Filter out cards that don't match the leading card suit
-        elif card.get_suit == first_card.get_suit() and card.get_value() > highest_card.get_value():
-            highest_card = card
-            winning_card = this_card
 
     return winning_card
 

--- a/euchre/cards.py
+++ b/euchre/cards.py
@@ -85,15 +85,20 @@ class Card():
         trump: -- the current trump object.
         """
         if self._suit == trump.get_suit():
+            return True
+        elif self._suit == trump.get_left() and self._rank == "Jack":
+            return True
+        return False
+
+    def update_to_trump(self, trump):
+        """Update this card's value with the new trump ranking value."""
+        if self._suit == trump.get_suit():
             # Get the new value of the trump
             self._value = trump.RANK[self._rank]
-            return True
             # Check for the other Jack of same color
         elif self._suit == trump.get_left() and self._rank == "Jack":
             # Subtract 1 to lower the strength for the left bower, adds suffix to rank for this effect
             self._value = trump.RANK[f'{self._rank}_L']
-            return True
-        return False            
             
     def get_value(self) -> int:
         """Return the numerical value of the card."""
@@ -140,10 +145,6 @@ class Card():
                 else:
                     return "ERROR - NOT VALID CARD VALUE. REMOVE FROM DECK."                
    
-    def _assign_symbol(self, suit: str):
-        """Get the symbol associated with the suit."""
-        return Card.SYMBOLS[suit]
-        
     def _assign_color(self, suit: str):
         """Get the color of the card suit.(i.e., "red", "black")"""
         if not suit:
@@ -158,3 +159,8 @@ class Card():
                 raise ValueError("Not Valid Suit Value")
         except ValueError as e:
             print(e)
+    
+    def _assign_symbol(self, suit: str):
+        """Get the symbol associated with the suit."""
+        return Card.SYMBOLS[suit]
+        


### PR DESCRIPTION
This fixes the issue where the leading card was always being returned in the function. 

The if statment checking if card was trump bypassed all cards, and didn't calculate the value. 

This is fixed now with this commit. 