### PR TITLE
Fixed card comparisons issues

### DIFF
--- a/euchre/__main__.py
+++ b/euchre/__main__.py
@@ -89,6 +89,7 @@ def play_cards(players: list[Player], trump: Trump) -> list[tuple[Player, Card]]
     trump: -- trump for current round.
     """
     cards_played = []
+    card_to_match = None
     for player in players:
         # check if player gets skipped because partner alone this round
         if player.get_skipped():
@@ -112,11 +113,11 @@ def play_cards(players: list[Player], trump: Trump) -> list[tuple[Player, Card]]
 
         # Get the card from the tuple of the enumerated list
         card_to_play = legal_cards[card][1]
+        player.remove_card(card_to_play)
+        cards_played.append((player, card_to_play))
 
         print(f'{player.get_name()} played {card_to_play}.')
         space_break()
-        player.remove_card(card_to_play)
-        cards_played.append((player, card_to_play))
         space_break()
         print('All cards played:')
         for card in cards_played:

--- a/euchre/__main__.py
+++ b/euchre/__main__.py
@@ -114,7 +114,7 @@ def play_cards(players: list[Player], trump: Trump) -> list[tuple[Player, Card]]
         card_to_play = legal_cards[card][1]
 
         print(f'{player.get_name()} played {card_to_play}.')
-        print('\n')
+        space_break()
         player.remove_card(card_to_play)
         cards_played.append((player, card_to_play))
         space_break()

--- a/euchre/__main__.py
+++ b/euchre/__main__.py
@@ -150,7 +150,7 @@ def get_highest_rank_card(cards: list[tuple[Player, Card]], trump: Trump) -> tup
             continue
 
         # Only compare cards that have the matching value or have a trump suit
-        if card.get_suit() == first_card.get_suit() or card.get_suit() == trump.get_suit():
+        if card.get_suit() == first_card.get_suit() or card.is_trump(trump):
 
             if card.get_value() > highest_card.get_value():
                 highest_card = card

--- a/euchre/__main__.py
+++ b/euchre/__main__.py
@@ -120,7 +120,7 @@ def play_cards(players: list[Player], trump: Trump) -> list[tuple[Player, Card]]
         space_break()
         print('All cards played:')
         for card in cards_played:
-            print(f'{card[0]} played {card[1]}')
+            print(f'\t{card[0]} played {card[1]}')
         
     return cards_played
 

--- a/euchre/cards.py
+++ b/euchre/cards.py
@@ -37,30 +37,6 @@ class Card():
         self._id = f'{self._rank}{self._suit}_{self._value}{self._color}'
         self._symbol = self._assign_symbol(self._suit)
 
-    # def __eq__(self, other):
-    #     """Compare if the cards are equal."""
-    #     return self._value == other.get_value()
-    
-    # def __ge__(self, other):
-    #     """Compare the cards greater equal."""
-    #     return self._value >= other.get_value()
-
-    # def __gt__(self, other):
-    #     """Compare if the cards are greater than for comparison."""
-    #     return self._value > other.get_value()
-    
-    # def __le__(self, other):
-    #     """Compare the cards less than equal."""
-    #     return self._value <= other.get_value()
-    
-    def __lt__(self, other):
-        """This is needed for sorting the cards."""
-        return self._suit < other.get_suit() 
-    
-    # def __ne__(self, other):
-    #     """Compare the cards not equal."""
-    #     return self._value != other.get_value()
-
     def __str__(self):
         """Return human friendly version of card."""
         if type(self._rank) == str:

--- a/euchre/cards.py
+++ b/euchre/cards.py
@@ -37,29 +37,29 @@ class Card():
         self._id = f'{self._rank}{self._suit}_{self._value}{self._color}'
         self._symbol = self._assign_symbol(self._suit)
 
-    def __eq__(self, other):
-        """Compare if the cards are equal."""
-        return self._value == other.get_value()
+    # def __eq__(self, other):
+    #     """Compare if the cards are equal."""
+    #     return self._value == other.get_value()
     
-    def __ge__(self, other):
-        """Compare the cards greater equal."""
-        return self._value >= other.get_value()
+    # def __ge__(self, other):
+    #     """Compare the cards greater equal."""
+    #     return self._value >= other.get_value()
 
-    def __gt__(self, other):
-        """Compare if the cards are greater than for comparison."""
-        return self._value > other.get_value()
+    # def __gt__(self, other):
+    #     """Compare if the cards are greater than for comparison."""
+    #     return self._value > other.get_value()
     
-    def __le__(self, other):
-        """Compare the cards less than equal."""
-        return self._value <= other.get_value()
+    # def __le__(self, other):
+    #     """Compare the cards less than equal."""
+    #     return self._value <= other.get_value()
     
     def __lt__(self, other):
-        """Compare the cards values are less than for comparison."""
+        """This is needed for sorting the cards."""
         return self._suit < other.get_suit() 
     
-    def __ne__(self, other):
-        """Compare the cards not equal."""
-        return self._value != other.get_value()
+    # def __ne__(self, other):
+    #     """Compare the cards not equal."""
+    #     return self._value != other.get_value()
 
     def __str__(self):
         """Return human friendly version of card."""

--- a/euchre/dealers.py
+++ b/euchre/dealers.py
@@ -4,13 +4,13 @@ Dealers module: is used to deal cards to players, pick up card, and track player
 from __future__ import annotations
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
-    from euchre.cards import Card
     from euchre.players import Player
 
 from collections import deque
 from random import sample
 
-from euchre.constants import DECK
+from euchre.cards import Card
+from euchre.constants import SUITS, VALUES
 
 class Dealer():
     """
@@ -53,9 +53,11 @@ class Dealer():
         players: -- list of players for whom the cards are dealt.
         deck: -- list of cards to deal.
         """
+        deck = self._deck()
+
         print('\n')
         print(f'{self._dealer_player} is dealing cards...')
-        shuffled = sample(DECK, len(DECK))
+        shuffled = sample(deck, len(deck))
         rounds = 0
         cards_to_deal = 3
         
@@ -141,3 +143,11 @@ class Dealer():
         """Get the leader player and make sure they are first in the order of play."""
         while self._player_order[-1] != self._dealer_player:
             self._get_new_order()
+
+    def _deck(self):
+        """Create a new deck to have clean setup of cards."""
+        deck = [
+            Card(value, suit) for value in VALUES for suit in SUITS
+        ]
+
+        return deck

--- a/euchre/players.py
+++ b/euchre/players.py
@@ -10,6 +10,9 @@ if TYPE_CHECKING:
     from euchre.teams import Team
     from euchre.trumps import Trump
 
+from colorama import just_fix_windows_console, Fore, Style
+just_fix_windows_console()
+
 from euchre.constants import SUITS
 
 
@@ -52,6 +55,8 @@ class Player():
     
     def __str__(self):
         """Return human-friendly version of player."""
+        if not self._is_bot:
+            return f'{Fore.YELLOW}{self._name}{Style.RESET_ALL}'
         return f'{self._name}'
     
     def __repr__(self):

--- a/euchre/players.py
+++ b/euchre/players.py
@@ -111,6 +111,9 @@ class Player():
         card_to_match: -- card to compare suits against to filter.
         trump: -- the curren trump for the round.
         """
+        if not card_to_match:
+            return []
+        
         # If Left Bower played first we need to filter for trump suits instead
         if card_to_match.is_trump(trump):
             suit_to_match = trump.get_suit()

--- a/euchre/players.py
+++ b/euchre/players.py
@@ -109,7 +109,7 @@ class Player():
         """Filters the list of cards in player's hand for legal cards and returns it.
             
         card_to_match: -- card to compare suits against to filter.
-        trump: -- the curren trump for the round.
+        trump: -- the current trump for the round.
         """
         if not card_to_match:
             return []

--- a/euchre/players.py
+++ b/euchre/players.py
@@ -83,7 +83,11 @@ class Player():
     def remove_card(self, card: Card):
         """Remove the Card object from the Player hand."""
         if card in self._cards:
-            self._cards.remove(card)
+            try:
+                self._cards.remove(card)
+            except ValueError as e:
+                print("Card doesn't exist in the player's hand.")
+                print(e)
     
     def get_cards(self) -> list[Card]:
         """Returns the list of cards in players hand. Cards are not listed."""
@@ -101,7 +105,7 @@ class Player():
             return list(enumerate(sorted(cards), start=1))
         return list(enumerate(sorted(self._cards, reverse=True), start=1))
     
-    def filter_cards(self, card_to_match: Card, trump: Trump):
+    def filter_cards(self, card_to_match: Card, trump: Trump) -> list[Card]:
         """Filters the list of cards in player's hand for legal cards and returns it.
             
         card_to_match: -- card to compare suits against to filter.

--- a/euchre/players.py
+++ b/euchre/players.py
@@ -102,8 +102,8 @@ class Player():
         # Start enumeration at 1 for player input simplicity.
         # If no list is provided, just return all the cards in hand instead.
         if cards:
-            return list(enumerate(sorted(cards), start=1))
-        return list(enumerate(sorted(self._cards, reverse=True), start=1))
+            return list(enumerate(cards, start=1))
+        return list(enumerate(self._cards, start=1))
     
     def filter_cards(self, card_to_match: Card, trump: Trump) -> list[Card]:
         """Filters the list of cards in player's hand for legal cards and returns it.

--- a/euchre/teams.py
+++ b/euchre/teams.py
@@ -15,7 +15,7 @@ from random import sample
 
 # Base Team class
 class Team():
-    def __init__(self, player_A, player_B, name):
+    def __init__(self, player_A: Player, player_B: Player, name: str):
         """Initialize the Team object and assign players and a name via arugments.
         Score is default to zero.
 
@@ -59,7 +59,7 @@ class Team():
         self._score += points
 
 # Team builder 
-def build_teams(teams_list: list[Team]) -> list[Team]:
+def build_teams(teams_list: list[Player]) -> list[Team]:
     """Initialize teams with random generated player teams list.
     
     Keyword arguments:

--- a/tests/test_cardComparisons.py
+++ b/tests/test_cardComparisons.py
@@ -1,0 +1,28 @@
+from unittest import TestCase
+from euchre.cards import Card
+
+class TestCardComparisons(TestCase):
+
+    def test_cardEqualByInstance(self):
+        c1 = Card(9, "Clubs")
+        c2 = Card(9, "Spades")
+
+        self.assertNotEqual(c1, c2)
+
+    
+    def test_cardEqualByValue(self):
+        c1 = Card(9, "Clubs")
+        c2 = Card(9, "Spades")
+
+        self.assertEqual(c1.get_value(), c2.get_value())
+
+    
+    def test_cardLessThanByInstance(self):
+        c1 = Card(9, "Clubs")
+        c2 = Card(9, "Spades")
+
+        # Cards are compared by sorting suit values
+        # therefore 'c' is less than 's'
+        is_equal = c1 < c2
+
+        self.assertEqual(is_equal, True)

--- a/tests/test_playerGameLoopMechanics.py
+++ b/tests/test_playerGameLoopMechanics.py
@@ -6,6 +6,8 @@ from euchre.teams import Team, assign_player_teams
 from euchre.trumps import Trump
 from euchre.__main__ import play_cards
 
+# These tests take a long time to process on the commandline
+# since they rely on input from the terminal
 class TestPlayerLoopMechanics(TestCase):
     def setUp(self):
         self.p1 = Player("Player_1")
@@ -25,15 +27,21 @@ class TestPlayerLoopMechanics(TestCase):
         # Computer players setup
         self.p2 = Player("Pig")
         self.jS = Card(11, "Spades")
+        self.jC = Card(11, "Clubs")
         self.p2.receive_card(self.jS)
+        self.p2.receive_card(self.jC)
 
         self.p3 = Player("Dog")
         self.kH = Card(13, "Hearts")
+        self.qS = Card(12, "Spades")
         self.p3.receive_card(self.kH)
+        self.p3.receive_card(self.qS)
 
         self.p4 = Player("Cow")
         self.aH = Card(14, "Hearts")
+        self.kS = Card(13, "Spades")
         self.p4.receive_card(self.aH)
+        self.p4.receive_card(self.kS)
 
         # Teams setup
         t1 = Team(self.p1, self.p3, "Player_team")
@@ -45,16 +53,67 @@ class TestPlayerLoopMechanics(TestCase):
         self.players = [self.p2, self.p3, self.p4, self.p1]
         self.trump = Trump("Spades")
 
-    @patch('builtins.input', return_value='1')
-    def test_playerHasCardAfterPlayingCard(self, input):
+    @patch('builtins.input', side_effect=['2','1','1','1'])
+    def test_loop_playersPlayCardFromHand(self, input):
         cards_played = play_cards(self.players, self.trump)
 
         self.assertEqual(cards_played, [
-            (self.p2, self.jS), 
-            (self.p3, self.kH), 
-            (self.p4, self.aH), 
+            (self.p2, self.jC), 
+            (self.p3, self.qS), 
+            (self.p4, self.kS), 
             (self.p1,self.pcAS)
         ])
+
+    @patch('builtins.input', side_effect=['2','1','1','1'])
+    def test_cardsInHandAfterPlaying(self, input):
+        cards_played = play_cards(self.players, self.trump)
+        
+        # Cards in players hand
+        #   self.pcAS = Card(14, "Spades") <- played 
+        #   self.pc9H = Card(9, "Hearts")
+        #   self.pcAD = Card(14, "Diamonds")
+        #   self.pcAC = Card(14, "Clubs")
+        #   self.pcQC = Card(12, "Clubs")
+        p1_cards = self.p1.get_cards()
+
+        self.assertEqual(p1_cards, [self.pc9H, self.pcAD, self.pcAC, self.pcQC])
+
+    
+    @patch('builtins.input', side_effect=['2','1','1','1'])
+    def test_listCardsAfterPlaying(self, input):
+        cards_played = play_cards(self.players, self.trump)
+        
+        # Cards in players hand
+        #   self.pcAS = Card(14, "Spades") <- played 
+        #   self.pc9H = Card(9, "Hearts")
+        #   self.pcAD = Card(14, "Diamonds")
+        #   self.pcAC = Card(14, "Clubs")
+        #   self.pcQC = Card(12, "Clubs")
+        p1_cards = self.p1.list_cards()
+
+        self.assertEqual(p1_cards, [
+            (1, self.pc9H),
+            (2, self.pcAD), 
+            (3, self.pcAC), 
+            (4, self.pcQC)
+        ])
+
+
+    @patch('builtins.input', side_effect=['2','1','1','1','1','1','1','1'])
+    def test_playerCardsPlayed_TwoHands(self, input):
+        cards_played_r1 = play_cards(self.players, self.trump)
+        cards_played_r2 = play_cards(self.players, self.trump)
+        
+        # Cards in players hand
+        #   self.pcAS = Card(14, "Spades")  <- played r1
+        #   self.pc9H = Card(9, "Hearts")   <- played r2
+        #   self.pcAD = Card(14, "Diamonds")
+        #   self.pcAC = Card(14, "Clubs")
+        #   self.pcQC = Card(12, "Clubs")
+        p1_card_r1 = cards_played_r1[3][1]
+        p1_card_r2 = cards_played_r2[3][1]
+
+        self.assertNotEqual(p1_card_r1, p1_card_r2)
         
 
 if __name__ == '__main__':

--- a/tests/test_playerGameLoopMechanics.py
+++ b/tests/test_playerGameLoopMechanics.py
@@ -8,6 +8,9 @@ from euchre.__main__ import play_cards
 
 # Set to False if you want to run all tests with skipIf decorator
 skip_passing = True
+skip_failing = False
+
+# TODO Actually implement tests for bots, right now they are actual human players
 
 # These tests take a long time to process on the commandline
 # since they rely on input from the terminal
@@ -125,7 +128,7 @@ class TestPlayerLoopMechanics(TestCase):
         self.assertNotEqual(p1_card_r1, p1_card_r2)
 
 
-    # @skipIf(skip_passing, "Test is working, skipping for now.")
+    @skipIf(skip_failing, "Test is failing, skipping for now.")
     @patch('builtins.input', side_effect=['2','1','1','1','1','1','1','1'])
     def test_LeaderCardsPlayed_TwoHands(self, input):
         cards_played_r1 = play_cards(self.players, self.trump)
@@ -143,7 +146,25 @@ class TestPlayerLoopMechanics(TestCase):
         self.assertNotEqual(p2_card_r1, p2_card_r2)
 
 
-    
+    @skipIf(skip_failing, "Test is failing, skipping for now.")
+    @patch('builtins.input', side_effect=['2','1','1','1','1','1','1','1'])
+    def test_LeaderCardsPlayed_TwoHands_listCards(self, input):
+        cards_played_r1 = play_cards(self.players, self.trump)
+        cards_played_r2 = play_cards(self.players, self.trump)
+        
+        # Cards in players hand
+        #   self.pcAS = Card(14, "Spades")  <- played r1
+        #   self.pc9H = Card(9, "Hearts")   <- played r2
+        #   self.pcAD = Card(14, "Diamonds")
+        #   self.pcAC = Card(14, "Clubs")
+        #   self.pcQC = Card(12, "Clubs")
+        cards = self.p2.list_cards()
+
+        self.assertEqual(cards, [])
+
+
+
+    @skipIf(skip_passing, "Test is passing, skipping for now.")
     def test_BotPlayer_CardsInHand(self):
         # self.p2 = Player("Pig")
         # self.jS = Card(11, "Spades")
@@ -151,6 +172,93 @@ class TestPlayerLoopMechanics(TestCase):
         cards = self.p2.get_cards()
         expected = [self.jS, self.jC]
 
+        self.assertEqual(cards, expected)
+
+
+    @skipIf(skip_passing, "Test is passing, skipping for now.")
+    def test_BotPlayer_CardsInHand_afterRemovingCard(self):
+        # self.p2 = Player("Pig")
+        # self.jS = Card(11, "Spades")
+        # self.jC = Card(11, "Clubs")
+        self.p2.remove_card(self.jC)
+
+        cards = self.p2.get_cards()
+        expected = [self.jS]
+
+        self.assertEqual(cards, expected)
+
+
+    @skipIf(skip_passing, "Test is passing, skipping for now.")
+    @patch('builtins.input', side_effect=['2','1','1','1'])
+    def test_BotPlayer_CardsInHand_afterPlayingCard(self, input):
+        cards_played = play_cards(self.players, self.trump)
+        
+        # self.p2 = Player("Pig")
+        # self.jS = Card(11, "Spades")
+        # self.jC = Card(11, "Clubs")
+
+        cards = self.p2.get_cards()
+        expected = [self.jS]
+
+        self.assertEqual(cards, expected)
+
+
+    @patch('builtins.input', side_effect=['2','1','1','1'])
+    def test_BotPlayer_listCards_afterPlayingCard(self, input):
+        cards_played = play_cards(self.players, self.trump)
+        
+        # self.p2 = Player("Pig")
+        # self.jS = Card(11, "Spades")
+        # self.jC = Card(11, "Clubs")
+
+        cards = self.p2.list_cards()
+        expected = [(1, self.jS)]
+
+        self.assertEqual(cards, expected)
+
+
+    @patch('builtins.input', side_effect=['2','1','1','1'])
+    def test_BotPlayer_filterCards_afterPlayingCard(self, input):
+        cards_played = play_cards(self.players, self.trump)
+        
+        # self.p2 = Player("Pig")
+        # self.jS = Card(11, "Spades")
+        # self.jC = Card(11, "Clubs")
+        filtered_cards = self.p2.filter_cards(None, self.trump)
+
+        cards = self.p2.list_cards(filtered_cards)
+        expected = [(1, self.jS)]
+
+        self.assertEqual(cards, expected)
+
+
+    @skipIf(skip_passing, "Test is passing, skipping for now.")
+    def test_BotPlayer_listCards_noFilter(self):
+
+        # self.p2 = Player("Pig")
+        # self.jS = Card(11, "Spades")
+        # self.jC = Card(11, "Clubs")
+
+        cards = self.p2.list_cards()
+        expected = [(1, self.jS), (2, self.jC)]
+
+        self.assertEqual(cards, expected)
+
+
+    @skipIf(skip_passing, "Test is passing, skipping for now.")
+    def test_BotPlayer_listCards_allTrumpInHand_withFilter_noTrumpSuit(self):
+
+        # self.p2 = Player("Pig")
+        # self.jS = Card(11, "Spades")
+        # self.jC = Card(11, "Clubs")
+
+        match = Card(9, "Hearts")
+
+        filtered_list = self.p2.filter_cards(match, self.trump)
+        cards = self.p2.list_cards(filtered_list)
+
+        expected = [(1, self.jS), (2, self.jC)]
+        
         self.assertEqual(cards, expected)
         
 

--- a/tests/test_playerGameLoopMechanics.py
+++ b/tests/test_playerGameLoopMechanics.py
@@ -1,10 +1,13 @@
 from unittest.mock import patch
-from unittest import TestCase, main
+from unittest import TestCase, main, skipIf
 from euchre.cards import Card
 from euchre.players import Player
 from euchre.teams import Team, assign_player_teams
 from euchre.trumps import Trump
 from euchre.__main__ import play_cards
+
+# Set to False if you want to run all tests with skipIf decorator
+skip_passing = True
 
 # These tests take a long time to process on the commandline
 # since they rely on input from the terminal
@@ -53,6 +56,8 @@ class TestPlayerLoopMechanics(TestCase):
         self.players = [self.p2, self.p3, self.p4, self.p1]
         self.trump = Trump("Spades")
 
+
+    @skipIf(skip_passing, "Test is working, skipping for now.")
     @patch('builtins.input', side_effect=['2','1','1','1'])
     def test_loop_playersPlayCardFromHand(self, input):
         cards_played = play_cards(self.players, self.trump)
@@ -64,6 +69,8 @@ class TestPlayerLoopMechanics(TestCase):
             (self.p1,self.pcAS)
         ])
 
+
+    @skipIf(skip_passing, "Test is working, skipping for now.")
     @patch('builtins.input', side_effect=['2','1','1','1'])
     def test_cardsInHandAfterPlaying(self, input):
         cards_played = play_cards(self.players, self.trump)
@@ -79,6 +86,7 @@ class TestPlayerLoopMechanics(TestCase):
         self.assertEqual(p1_cards, [self.pc9H, self.pcAD, self.pcAC, self.pcQC])
 
     
+    @skipIf(skip_passing, "Test is working, skipping for now.")
     @patch('builtins.input', side_effect=['2','1','1','1'])
     def test_listCardsAfterPlaying(self, input):
         cards_played = play_cards(self.players, self.trump)
@@ -99,6 +107,7 @@ class TestPlayerLoopMechanics(TestCase):
         ])
 
 
+    @skipIf(skip_passing, "Test is working, skipping for now.")
     @patch('builtins.input', side_effect=['2','1','1','1','1','1','1','1'])
     def test_playerCardsPlayed_TwoHands(self, input):
         cards_played_r1 = play_cards(self.players, self.trump)
@@ -114,6 +123,35 @@ class TestPlayerLoopMechanics(TestCase):
         p1_card_r2 = cards_played_r2[3][1]
 
         self.assertNotEqual(p1_card_r1, p1_card_r2)
+
+
+    # @skipIf(skip_passing, "Test is working, skipping for now.")
+    @patch('builtins.input', side_effect=['2','1','1','1','1','1','1','1'])
+    def test_LeaderCardsPlayed_TwoHands(self, input):
+        cards_played_r1 = play_cards(self.players, self.trump)
+        cards_played_r2 = play_cards(self.players, self.trump)
+        
+        # Cards in players hand
+        #   self.pcAS = Card(14, "Spades")  <- played r1
+        #   self.pc9H = Card(9, "Hearts")   <- played r2
+        #   self.pcAD = Card(14, "Diamonds")
+        #   self.pcAC = Card(14, "Clubs")
+        #   self.pcQC = Card(12, "Clubs")
+        p2_card_r1 = cards_played_r1[0][1]
+        p2_card_r2 = cards_played_r2[0][1]
+
+        self.assertNotEqual(p2_card_r1, p2_card_r2)
+
+
+    
+    def test_BotPlayer_CardsInHand(self):
+        # self.p2 = Player("Pig")
+        # self.jS = Card(11, "Spades")
+        # self.jC = Card(11, "Clubs")
+        cards = self.p2.get_cards()
+        expected = [self.jS, self.jC]
+
+        self.assertEqual(cards, expected)
         
 
 if __name__ == '__main__':

--- a/tests/test_playerGameLoopMechanics.py
+++ b/tests/test_playerGameLoopMechanics.py
@@ -1,0 +1,61 @@
+from unittest.mock import patch
+from unittest import TestCase, main
+from euchre.cards import Card
+from euchre.players import Player
+from euchre.teams import Team, assign_player_teams
+from euchre.trumps import Trump
+from euchre.__main__ import play_cards
+
+class TestPlayerLoopMechanics(TestCase):
+    def setUp(self):
+        self.p1 = Player("Player_1")
+        
+        self.pcAS = Card(14, "Spades")
+        self.pc9H = Card(9, "Hearts")
+        self.pcAD = Card(14, "Diamonds")
+        self.pcAC = Card(14, "Clubs")
+        self.pcQC = Card(12, "Clubs")
+
+        self.p1.receive_card(self.pcAS)
+        self.p1.receive_card(self.pc9H)
+        self.p1.receive_card(self.pcAD)
+        self.p1.receive_card(self.pcAC)
+        self.p1.receive_card(self.pcQC)
+
+        # Computer players setup
+        self.p2 = Player("Pig")
+        self.jS = Card(11, "Spades")
+        self.p2.receive_card(self.jS)
+
+        self.p3 = Player("Dog")
+        self.kH = Card(13, "Hearts")
+        self.p3.receive_card(self.kH)
+
+        self.p4 = Player("Cow")
+        self.aH = Card(14, "Hearts")
+        self.p4.receive_card(self.aH)
+
+        # Teams setup
+        t1 = Team(self.p1, self.p3, "Player_team")
+        t2 = Team(self.p2, self.p4, "Opponent_team")
+        t = [t1, t2]
+        assign_player_teams(t)
+
+        # Turn order
+        self.players = [self.p2, self.p3, self.p4, self.p1]
+        self.trump = Trump("Spades")
+
+    @patch('builtins.input', return_value='1')
+    def test_playerHasCardAfterPlayingCard(self, input):
+        cards_played = play_cards(self.players, self.trump)
+
+        self.assertEqual(cards_played, [
+            (self.p2, self.jS), 
+            (self.p3, self.kH), 
+            (self.p4, self.aH), 
+            (self.p1,self.pcAS)
+        ])
+        
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_playerMethods.py
+++ b/tests/test_playerMethods.py
@@ -147,8 +147,8 @@ class TestPlayerMethods(TestCase):
 
         self.assertEqual(p1.filter_cards(c1, trump), [pc1, pc3])
 
-
-    def test_getPlayerCard(self):
+    @patch('builtins.input', return_value='1')
+    def test_getPlayerCard(self, input):
         p1 = Player("Player_1")
         pc1 = Card(10, "Diamonds")
         pc2 = Card(11, "Diamonds")

--- a/tests/test_playerMethods.py
+++ b/tests/test_playerMethods.py
@@ -1,0 +1,172 @@
+from unittest.mock import patch
+from unittest import TestCase, main
+from euchre.cards import Card
+from euchre.players import Player
+from euchre.trumps import Trump
+
+class TestPlayerMethods(TestCase):
+    
+    def test_getName(self):
+        p1 = Player("Player_1")
+        self.assertEqual(p1.get_name(), "Player_1")
+
+
+    def test_receiveCard(self):
+        card = Card(9, "Spades")
+        p1 = Player("Player_1")
+        
+        p1.receive_card(card)
+        
+        self.assertEqual(p1.get_cards(), [card])
+
+
+    def test_removeCard(self):
+        card = Card(14, "Spades")
+        p1 = Player("Player_1")
+
+        p1.receive_card(card)
+        p1.remove_card(card)
+
+        self.assertEqual(p1.get_cards(), [])
+
+
+    def test_listCards(self):
+        card = Card(13, "Diamonds")
+        p1 = Player("Player_1")
+
+        p1.receive_card(card)
+
+        self.assertEqual(p1.list_cards(), [(1, card)])
+
+
+    def test_listCards_noCards(self):
+        p1 = Player("Player_1")
+
+        self.assertEqual(p1.list_cards(), [])
+
+
+    def test_filterCards(self):
+        p1 = Player("Player_1")
+        pc1 = Card(10, "Hearts")
+        p1.receive_card(pc1)
+
+        c1 = Card(9, "Hearts")
+        trump = Trump("Spades")
+
+        self.assertEqual(p1.filter_cards(c1, trump), [pc1])
+
+
+    def test_filterCards_notMatchingFilter(self):
+        p1 = Player("Player_1")
+        pc1 = Card(10, "Spades")
+        p1.receive_card(pc1)
+
+        c1 = Card(9, "Hearts")
+        trump = Trump("Spades")
+
+        self.assertEqual(p1.filter_cards(c1, trump), [])
+
+    
+    def test_filterCards_fullHand_OneValid(self):
+        p1 = Player("Player_1")
+        pc1 = Card(10, "Hearts")
+        pc2 = Card(11, "Hearts")
+        pc3 = Card(12, "Hearts")
+        pc4 = Card(13, "Hearts")
+        pc5 = Card(14, "Clubs")
+
+        p1.receive_card(pc1)
+        p1.receive_card(pc2)
+        p1.receive_card(pc3)
+        p1.receive_card(pc4)
+        p1.receive_card(pc5)
+
+        c1 = Card(9, "Clubs")
+        trump = Trump("Spades")
+
+        self.assertEqual(p1.filter_cards(c1, trump), [pc5])
+
+
+    def test_filterCards_fullHand_ManyValid(self):
+        p1 = Player("Player_1")
+        pc1 = Card(10, "Hearts")
+        pc2 = Card(11, "Hearts")
+        pc3 = Card(12, "Hearts")
+        pc4 = Card(13, "Hearts")
+        pc5 = Card(14, "Clubs")
+
+        p1.receive_card(pc1)
+        p1.receive_card(pc2)
+        p1.receive_card(pc3)
+        p1.receive_card(pc4)
+        p1.receive_card(pc5)
+
+        c1 = Card(9, "Hearts")
+        trump = Trump("Spades")
+
+        self.assertEqual(p1.filter_cards(c1, trump), [pc1, pc2, pc3, pc4])
+
+
+    def test_filterCards_TrumpLead(self):
+        p1 = Player("Player_1")
+        pc1 = Card(10, "Spades")
+        pc2 = Card(10, "Hearts")
+        p1.receive_card(pc1)
+        p1.receive_card(pc2)
+
+        c1 = Card(9, "Spades")
+        trump = Trump("Spades")
+
+        self.assertEqual(p1.filter_cards(c1, trump), [pc1])
+
+
+    def test_filterCards_TrumpLead_LeftBowerInHand(self):
+        p1 = Player("Player_1")
+        pc1 = Card(11, "Clubs")
+        pc2 = Card(10, "Hearts")
+        p1.receive_card(pc1)
+        p1.receive_card(pc2)
+
+        c1 = Card(9, "Spades")
+        trump = Trump("Spades")
+
+        self.assertEqual(p1.filter_cards(c1, trump), [pc1])
+
+
+    def test_filterCards_TrumpLead_BothBowersInHand(self):
+        p1 = Player("Player_1")
+        pc1 = Card(11, "Clubs")
+        pc2 = Card(10, "Hearts")
+        pc3 = Card(11, "Spades")
+        p1.receive_card(pc1)
+        p1.receive_card(pc2)
+        p1.receive_card(pc3)
+        
+        c1 = Card(9, "Spades")
+        trump = Trump("Spades")
+
+        self.assertEqual(p1.filter_cards(c1, trump), [pc1, pc3])
+
+
+    def test_getPlayerCard(self):
+        p1 = Player("Player_1")
+        pc1 = Card(10, "Diamonds")
+        pc2 = Card(11, "Diamonds")
+        pc3 = Card(12, "Hearts")
+        pc4 = Card(13, "Spades")
+        pc5 = Card(9, "Clubs")
+
+        p1.receive_card(pc1)
+        p1.receive_card(pc2)
+        p1.receive_card(pc3)
+        p1.receive_card(pc4)
+        p1.receive_card(pc5)
+
+        card_list = p1.list_cards()
+
+        self.assertEqual(p1.get_player_card(card_list), 1)
+
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_playerMethods.py
+++ b/tests/test_playerMethods.py
@@ -165,8 +165,7 @@ class TestPlayerMethods(TestCase):
         card_list = p1.list_cards()
 
         self.assertEqual(p1.get_player_card(card_list), 1)
-
-
+        
 
 if __name__ == '__main__':
     main()

--- a/tests/test_scoreHighestRanking.py
+++ b/tests/test_scoreHighestRanking.py
@@ -273,6 +273,21 @@ class TestScoreTrick(unittest.TestCase):
         
         self.assertEqual(winner_test, winner_expected)
 
+    
+    def test_getHighestRankingCard_JackMiddle_JackLeftBower_AllTrumps(self):
+
+        cards_played = [
+            (self.p1, self.cQc),
+            (self.p2, self.cKc),
+            (self.p3, self.cJs),
+            (self.p4, self.c10c)
+        ]
+
+        winner_test = get_highest_rank_card(cards_played, self.tC)
+        winner_expected = (self.p3, self.cJs)
+        
+        self.assertEqual(winner_test, winner_expected)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_scoreHighestRanking.py
+++ b/tests/test_scoreHighestRanking.py
@@ -243,6 +243,7 @@ class TestScoreTrick(unittest.TestCase):
         
         self.assertEqual(winner_test, winner_expected)
 
+
     def test_getHighestRankingCard_lead_Q_with_mixed_withLowTrumps(self):
 
         cards_played = [
@@ -254,6 +255,21 @@ class TestScoreTrick(unittest.TestCase):
 
         winner_test = get_highest_rank_card(cards_played, self.tS)
         winner_expected = (self.p3, self.c9s)
+        
+        self.assertEqual(winner_test, winner_expected)
+
+    
+    def test_getHighestRankingCard_JackMiddle_noTrumps(self):
+
+        cards_played = [
+            (self.p1, self.cKs),
+            (self.p2, self.c10s),
+            (self.p3, self.cJs),
+            (self.p4, self.c9s)
+        ]
+
+        winner_test = get_highest_rank_card(cards_played, self.tH)
+        winner_expected = (self.p1, self.cKs)
         
         self.assertEqual(winner_test, winner_expected)
 


### PR DESCRIPTION
The methods for comparison weren't tested, and implemented as a best practice anyways. This caused issues where the comparison of the cards was affected.

When comparing if a Jack of Spades was a Jack of clubs, the default implementation was checking only by value, therefore removing if it appeared in the list of cards earlier than the intended card. 

Removed the methods, to be implemented later possibly. Also cleaned up some code not in scope but won't affect anything as its organizational and not functional. 

Added testing suite for these issues as well. 