### PR TITLE
Fixed the sorting issues of cards in hand

### DIFF
--- a/euchre/cards.py
+++ b/euchre/cards.py
@@ -37,6 +37,19 @@ class Card():
         self._id = f'{self._rank}{self._suit}_{self._value}{self._color}'
         self._symbol = self._assign_symbol(self._suit)
 
+    def __gt__(self, other):
+        return self.get_value() > other.get_value()
+    
+    def __ge__(self, other):
+        return self.get_value() >= other.get_value()
+    
+    def __lt__(self, other):
+        """Necessary for sorting purposes."""
+        return self.get_value() < other.get_value()
+    
+    def __le__(self, other):
+        return self.get_value() <= other.get_value()
+
     def __str__(self):
         """Return human friendly version of card."""
         if type(self._rank) == str:

--- a/euchre/players.py
+++ b/euchre/players.py
@@ -90,7 +90,10 @@ class Player():
                 print(e)
     
     def get_cards(self) -> list[Card]:
-        """Returns the list of cards in players hand. Cards are not listed."""
+        """Returns the list of cards in players hand. Cards are sorted by rank and suit."""
+        # Sort by suit
+        # Sort by Rank
+        # Return combined sorted list of cards
         return self._cards
     
     def list_cards(self, cards: list[Card]=None) -> list[tuple [int, Card]]:
@@ -103,7 +106,7 @@ class Player():
         # If no list is provided, just return all the cards in hand instead.
         if cards:
             return list(enumerate(cards, start=1))
-        return list(enumerate(self._cards, start=1))
+        return list(enumerate(self.get_cards(), start=1))
     
     def filter_cards(self, card_to_match: Card, trump: Trump) -> list[Card]:
         """Filters the list of cards in player's hand for legal cards and returns it.
@@ -122,7 +125,7 @@ class Player():
 
         legal_list = []
 
-        for card in self._cards:
+        for card in self.get_cards():
             suit = card.get_suit()
             # Special case for Left Bower played later in round, and shares suit with lead card.
             if suit == suit_to_match and not card_to_match.is_trump(trump) and card.is_trump(trump):
@@ -226,14 +229,14 @@ class Player():
         """Set tricks increasing value of tricks by one."""
         self._tricks += 1
 
-    def is_alone(self) -> bool:
-        """Return status if player is playing alone this round."""
-        return self._is_alone
-    
     def is_bot(self) -> bool:
         """Return status if player is a bot."""
         return self._is_bot
 
+    def is_alone(self) -> bool:
+        """Return status if player is playing alone this round."""
+        return self._is_alone
+    
     def set_alone(self, alone: bool):
         """Set alone status for the Player object."""
         if alone == True:
@@ -274,8 +277,18 @@ class Player():
         self._is_skipped = skipped
         self._cards.clear()
 
+    def sort_cards_by_suit(self) -> dict[Card]:
+        """Sorts the cards by suit."""
+        sorted = { k: [] for k in SUITS }
+
+        for card in self._cards:
+            if card.get_suit() in sorted:
+                sorted[card.get_suit()].append(card)
+
+        return sorted
+    
     def reset(self):
-        """Reset tricks for new round of play."""
+        """Reset player attribute status for new round of play."""
         self._cards.clear()
         self._tricks = 0
         self._is_alone = False

--- a/euchre/players.py
+++ b/euchre/players.py
@@ -91,10 +91,8 @@ class Player():
     
     def get_cards(self) -> list[Card]:
         """Returns the list of cards in players hand. Cards are sorted by rank and suit."""
-        # Sort by suit
         # Sort by Rank
-        # Return combined sorted list of cards
-        return self._cards
+        return self.sorted_cards_in_hand()
     
     def list_cards(self, cards: list[Card]=None) -> list[tuple [int, Card]]:
         """Returns enumerated list of cards currently in hand. If no cards list passed, all cards returned.

--- a/euchre/players.py
+++ b/euchre/players.py
@@ -278,7 +278,7 @@ class Player():
         self._cards.clear()
 
     def sort_cards_by_suit(self) -> dict[Card]:
-        """Sorts the cards by suit."""
+        """Sorts the cards by suit. Returns a dictionary of sorted cards."""
         sorted = { k: [] for k in SUITS }
 
         for card in self._cards:
@@ -286,6 +286,28 @@ class Player():
                 sorted[card.get_suit()].append(card)
 
         return sorted
+    
+    def sort_cards_by_value(self) -> dict[Card]:
+        """Sorts the cards by value. Returns a new dictionary of cards in hand."""
+        suit_sorted = self.sort_cards_by_suit()
+        value_sorted = {}
+
+        for k, v in suit_sorted.items():
+            value_sorted[k] = sorted(v, reverse=True)
+
+        return value_sorted
+    
+    def sorted_cards_in_hand(self) -> list[Card]:
+        """Return a sorted list of cards in hand."""
+        cards = []
+        # TODO add ability for adding trump at front of list
+        buckets = self.sort_cards_by_value()
+        for bucket in buckets.values():
+            cards.extend(bucket)
+
+        return cards
+
+
     
     def reset(self):
         """Reset player attribute status for new round of play."""

--- a/tests/test_cardSorting.py
+++ b/tests/test_cardSorting.py
@@ -1,0 +1,45 @@
+from unittest import TestCase, main
+from euchre.cards import Card
+from euchre.players import Player
+from euchre.constants import SUITS
+
+class TestCardSorting(TestCase):
+
+    def test_cardSorting(self):
+        p1 = Player("Player_1")
+        c1 = Card(9, "Diamonds")
+
+        p1.receive_card(c1)
+        sorted = p1.sort_cards_by_suit()
+        expected = { k: [] for k in SUITS}
+        expected['Diamonds'].append(c1)
+
+        self.assertEqual(sorted, expected)
+
+
+    def test_cardSorting_everySuit(self):
+        p1 = Player("Player_1")
+        c1 = Card(9, "Diamonds")
+        c2 = Card(9, "Hearts")
+        c3 = Card(9, "Clubs")
+        c4 = Card(9, "Spades")
+
+        p1.receive_card(c1)
+        p1.receive_card(c2)
+        p1.receive_card(c3)
+        p1.receive_card(c4)
+
+        sorted = p1.sort_cards_by_suit()
+        expected = { k: [] for k in SUITS}
+
+        expected['Diamonds'].append(c1)
+        expected['Hearts'].append(c2)
+        expected['Clubs'].append(c3)
+        expected['Spades'].append(c4)
+
+        self.assertEqual(sorted, expected)
+
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_cardSorting.py
+++ b/tests/test_cardSorting.py
@@ -40,6 +40,73 @@ class TestCardSorting(TestCase):
         self.assertEqual(sorted, expected)
 
 
+    def test_cardSorting_sameSuit_MixedValues(self):
+        p1 = Player("Player_1")
+        c1 = Card(11, "Diamonds")
+        c2 = Card(14, "Diamonds")
+        c3 = Card(12, "Diamonds")
+        c4 = Card(9, "Diamonds")
+
+        p1.receive_card(c1)
+        p1.receive_card(c2)
+        p1.receive_card(c3)
+        p1.receive_card(c4)
+
+        sorted = p1.sort_cards_by_suit()
+        expected = { k: [] for k in SUITS}
+
+        expected['Diamonds'].append(c1)
+        expected['Diamonds'].append(c2)
+        expected['Diamonds'].append(c3)
+        expected['Diamonds'].append(c4)
+
+        self.assertEqual(sorted, expected)
+
+
+    def test_cardSorting_sameSuit_SortedValues(self):
+        p1 = Player("Player_1")
+        c1 = Card(11, "Diamonds")
+        c2 = Card(14, "Diamonds")
+        c3 = Card(12, "Diamonds")
+        c4 = Card(9, "Diamonds")
+
+        p1.receive_card(c1)
+        p1.receive_card(c2)
+        p1.receive_card(c3)
+        p1.receive_card(c4)
+
+        sorted = p1.sort_cards_by_value()
+        expected = { k: [] for k in SUITS}
+
+        expected['Diamonds'].append(c2) # Ace
+        expected['Diamonds'].append(c3) # Queen
+        expected['Diamonds'].append(c1) # Jack
+        expected['Diamonds'].append(c4) # 9
+
+        self.assertEqual(sorted, expected)
+
+
+    def test_cardSorting_inHand(self):
+        p1 = Player("Player_1")
+
+        c1 = Card(11, "Diamonds")
+        c2 = Card(14, "Diamonds")
+        c3 = Card(12, "Diamonds")
+        p1.receive_card(c1)
+        p1.receive_card(c2)
+        p1.receive_card(c3)
+
+        c5 = Card(9, "Spades")
+        c6 = Card(14, "Spades")
+        p1.receive_card(c5)
+        p1.receive_card(c6)
+
+        # Order = ("Spades", "Diamonds", "Clubs", "Hearts")
+        sorted = p1.sorted_cards_in_hand()
+        expected = [c6, c5, c2, c3, c1 ]
+
+        self.assertEqual(sorted, expected)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fixed the sorting issues of the cards in hand from prior commit. Basically kept most of the implementations of the dunder methods for all comparison operators other than __eq__ and __ne__.

Implemented three sorting methods, or rather two and a rebuilding method. Sorting by suit, then by value. Finally adding to hand in New Deck order by suit.

This provides for a cleaner experience when displaying the cards. Didn't implement elevating Trump in the order because the current trump is always seen in the display when selecting cards.

